### PR TITLE
fix: replace bare excepts with specific exception types

### DIFF
--- a/examples/demo_regression.py
+++ b/examples/demo_regression.py
@@ -8,7 +8,7 @@ import torch
 
 try:
     from sklearn.metrics import root_mean_squared_error as mean_squared_error
-except:
+except ImportError:
     from sklearn.metrics import mean_squared_error
     mean_squared_error = partial(mean_squared_error, squared=False)
 import os, sys

--- a/inference/preprocess.py
+++ b/inference/preprocess.py
@@ -41,7 +41,7 @@ class SelectiveInversePipeline(Pipeline):
             name, transformer = self.steps[step_idx]
             try:
                 check_is_fitted(transformer)
-            except:
+            except Exception:
                 continue
             
             if name in self.skip_inverse:

--- a/inference_regression.py
+++ b/inference_regression.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from sklearn.metrics import r2_score
 try:
     from sklearn.metrics import root_mean_squared_error as mean_squared_error
-except:
+except ImportError:
     from sklearn.metrics import mean_squared_error
     mean_squared_error = partial(mean_squared_error, squared=False)
 from inference.predictor import LimiXPredictor


### PR DESCRIPTION
Replace bare `except:` with specific exception types across 3 files.

**Changes:**
- `examples/demo_regression.py`: `except:` → `except ImportError:` (sklearn import fallback)
- `inference_regression.py`: `except:` → `except ImportError:` (sklearn import fallback)
- `inference/preprocess.py`: `except:` → `except Exception:` (check_is_fitted fallback)

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`, masking critical signals. Using specific types preserves behavior while improving debuggability.